### PR TITLE
Lower fastify-plugin version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-accepts-serializer.svg)](https://greenkeeper.io/) [![Build Status](https://travis-ci.org/fastify/fastify-accepts-serializer.svg?branch=master)](https://travis-ci.org/fastify/fastify-accepts-serializer) [![Coverage Status](https://coveralls.io/repos/github/fastify/fastify-accepts-serializer/badge.svg?branch=master)](https://coveralls.io/github/fastify/fastify-accepts-serializer?branch=master)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-Serializer according to the `Accept` header. Supports Fastify versions ^2.0.0
+Serializer according to the `Accept` header. Supports Fastify versions >=1.10.0
 
 ## Install
 ```sh

--- a/index.js
+++ b/index.js
@@ -55,6 +55,6 @@ function acceptsSerializerPlugin (fastify, options, next) {
 }
 
 module.exports = fp(acceptsSerializerPlugin, {
-  fastify: '^2.0.0',
+  fastify: '>=1.10.0',
   name: 'fastify-accepts-serializer'
 })


### PR DESCRIPTION
Looks like this is the best it can get without breaking.

Now that I think, a dev utility that displays the lowest Fastify version a plugin can support would be very helpful to display something like:

![capture](https://user-images.githubusercontent.com/1297759/49140173-a8127200-f304-11e8-8139-64e3e047bada.PNG)
