### PR TITLE
Prepare for 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-accepts-serializer.svg)](https://greenkeeper.io/) [![Build Status](https://travis-ci.org/fastify/fastify-accepts-serializer.svg?branch=master)](https://travis-ci.org/fastify/fastify-accepts-serializer) [![Coverage Status](https://coveralls.io/repos/github/fastify/fastify-accepts-serializer/badge.svg?branch=master)](https://coveralls.io/github/fastify/fastify-accepts-serializer?branch=master)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-Serializer according to the `Accept` header. Supports Fastify versions >=1.10.0
+Serializer according to the `Accept` header. Supports Fastify versions `^1.10.0`
 
 ## Install
 ```sh

--- a/index.js
+++ b/index.js
@@ -55,6 +55,6 @@ function acceptsSerializerPlugin (fastify, options, next) {
 }
 
 module.exports = fp(acceptsSerializerPlugin, {
-  fastify: '>=1.10.0',
+  fastify: '^1.10.0',
   name: 'fastify-accepts-serializer'
 })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-accepts-serializer#readme",
   "devDependencies": {
-    "fastify": "2.0.0-rc.0",
+    "fastify": "^1.10.0",
     "msgpack5": "^4.2.1",
     "pre-commit": "^1.2.2",
     "protobufjs": "^6.8.8",


### PR DESCRIPTION
Based on the discussion in #6 and the approach in `fastify-static`.

Once this PR is merged we should publish `1.x` as the latest, branch off and publish `2.0.0` as the next.

Versions `1.0.0` and `1.0.1` will be missing from npm though not sure if it will be a problem.

cc @allevo 