### PR TITLE
Fix wrong dependency version for 2.x (fixes #19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "yamljs": "^0.3.0"
   },
   "dependencies": {
-    "fastify-accepts": ">=0.5.0",
+    "fastify-accepts": "^0.5.0 || ^1.0.0",
     "fastify-plugin": "^1.2.1"
   }
 }


### PR DESCRIPTION
Fixes #19.

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (`npm run benchmark` doesn't exist)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
