### PR TITLE
Move test to node test framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard --verbose | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 node --test test/*.js",
     "test:typescript": "tsd"
   },
   "pre-commit": [
@@ -27,12 +27,13 @@
   "homepage": "https://github.com/fastify/fastify-accepts-serializer#readme",
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
+    "@types/node": "^20.11.1",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0",
     "msgpack5": "^6.0.2",
     "protobufjs": "^7.2.6",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "tap": "^18.7.1",
     "tsd": "^0.31.1",
     "yamljs": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard --verbose | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "c8 node --test test/*.js",
+    "test:unit": "c8 --100 node --test test/*.js",
     "test:typescript": "tsd"
   },
   "pre-commit": [
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/fastify/fastify-accepts-serializer#readme",
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
-    "@types/node": "^20.11.1",
     "c8": "^10.1.2",
     "fastify": "^5.0.0",
     "msgpack5": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard --verbose | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "c8 --100 node --test test/*.js",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "pre-commit": [

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const t = require('tap')
+const t = require('node:test')
+const assert = require('node:assert')
 const test = t.test
 
 const plugin = require('../')
@@ -12,9 +13,7 @@ const msgpack = require('msgpack5')()
 const root = protobuf.loadSync('test/awesome.proto')
 const AwesomeMessage = root.lookupType('awesomepackage.AwesomeMessage')
 
-test('serializer', t => {
-  t.plan(4)
-
+test('serializer', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin, {
@@ -41,76 +40,64 @@ test('serializer', t => {
     reply.send({ pippo: 'pluto' })
   })
 
-  t.test('application/yaml -> yaml', t => {
-    t.plan(3)
-    fastify.inject({
+  await t.test('application/yaml -> yaml', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/yaml'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/yaml')
-      t.strictSame(res.payload, YAML.stringify({ pippo: 'pluto' }))
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/yaml')
+    assert.deepStrictEqual(res.payload, YAML.stringify({ pippo: 'pluto' }))
   })
 
-  t.test('application/x-protobuf -> protobuf', t => {
-    t.plan(3)
-    fastify.inject({
+  await t.test('application/x-protobuf -> protobuf', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/x-protobuf'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/x-protobuf')
-      t.strictSame(res.payload, AwesomeMessage.encode(AwesomeMessage.create({ pippo: 'pluto' })).finish().toString())
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/x-protobuf')
+    assert.deepStrictEqual(res.payload, AwesomeMessage.encode(AwesomeMessage.create({ pippo: 'pluto' })).finish().toString())
   })
 
-  t.test('application/x-protobuf -> protobuf', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('application/x-protobuf -> protobuf', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/x-protobuf'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/x-protobuf')
-      t.strictSame(res.payload, AwesomeMessage.encode(AwesomeMessage.create({ pippo: 'pluto' })).finish().toString())
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/x-protobuf')
+    assert.deepStrictEqual(res.payload, AwesomeMessage.encode(AwesomeMessage.create({ pippo: 'pluto' })).finish().toString())
   })
 
-  t.test('application/x-msgpack -> msgpack', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('application/x-msgpack -> msgpack', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/x-msgpack'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/x-msgpack')
-      t.strictSame(res.payload, msgpack.encode({ pippo: 'pluto' }).toString())
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/x-msgpack')
+    assert.deepStrictEqual(res.payload, msgpack.encode({ pippo: 'pluto' }).toString())
   })
 })
 
-test('serializer - default = undefined', t => {
-  t.plan(1)
-
+test('serializer - default = undefined', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin, {
@@ -126,31 +113,27 @@ test('serializer - default = undefined', t => {
     reply.send({ pippo: 'pluto' })
   })
 
-  t.test('no match -> 406', t => {
-    t.plan(4)
-
-    fastify.inject({
+  await t.test('no match -> 406', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'text/html'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/json; charset=utf-8')
-      t.strictSame(res.statusCode, 406)
-      t.strictSame(res.payload, JSON.stringify({
-        statusCode: 406,
-        error: 'Not Acceptable',
-        message: 'Allowed: /^application\\/yaml$/,application/json'
-      }))
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    assert.deepStrictEqual(res.statusCode, 406)
+    assert.deepStrictEqual(res.payload, JSON.stringify({
+      statusCode: 406,
+      error: 'Not Acceptable',
+      message: 'Allowed: /^application\\/yaml$/,application/json'
+    }))
   })
 })
 
-test('serializer - default = application/json by fastify', t => {
-  t.plan(1)
+test('serializer - default = application/json by fastify', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin, {
@@ -162,27 +145,22 @@ test('serializer - default = application/json by fastify', t => {
     reply.send({ pippo: 'pluto' })
   })
 
-  t.test('no match -> json', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('no match -> json', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'text/html'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/json; charset=utf-8')
-      t.strictSame(res.payload, JSON.stringify({ pippo: 'pluto' }))
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    assert.deepStrictEqual(res.payload, JSON.stringify({ pippo: 'pluto' }))
   })
 })
 
-test('serializer - default = application/json by custom', t => {
-  t.plan(1)
-
+test('serializer - default = application/json by custom', async t => {
   const fastify = Fastify()
   fastify.register(plugin, {
     serializers: [
@@ -198,27 +176,22 @@ test('serializer - default = application/json by custom', t => {
     reply.send({ pippo: 'pluto' })
   })
 
-  t.test('no match -> json', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('no match -> json', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'text/html'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/json')
-      t.strictSame(res.payload, 'my-custom-string')
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/json')
+    assert.deepStrictEqual(res.payload, 'my-custom-string')
   })
 })
 
-test('serializer - default = application/yaml', t => {
-  t.plan(1)
-
+test('serializer - default = application/yaml', async t => {
   const fastify = Fastify()
   fastify.register(plugin, {
     serializers: [
@@ -234,27 +207,22 @@ test('serializer - default = application/yaml', t => {
     reply.send({ pippo: 'pluto' })
   })
 
-  t.test('no match -> yaml', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('no match -> yaml', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'text/html'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/yaml')
-      t.strictSame(res.payload, YAML.stringify({ pippo: 'pluto' }))
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/yaml')
+    assert.deepStrictEqual(res.payload, YAML.stringify({ pippo: 'pluto' }))
   })
 })
 
-test('serializer per route', t => {
-  t.plan(2)
-
+test('serializer per route', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin, {
@@ -280,44 +248,36 @@ test('serializer per route', t => {
       .send({ pippo: 'pluto' })
   })
 
-  t.test('overwrite', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('overwrite', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/yaml'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/yaml')
-      t.strictSame(res.payload, 'my-custom-string')
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/yaml')
+    assert.deepStrictEqual(res.payload, 'my-custom-string')
   })
 
-  t.test('not defined globally', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('not defined globally', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request2',
       payload: {},
       headers: {
         accept: 'application/x-msgpack'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/x-msgpack')
-      t.strictSame(res.payload, 'my-custom-string-msgpack')
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/x-msgpack')
+    assert.deepStrictEqual(res.payload, 'my-custom-string-msgpack')
   })
 })
 
-test('serializer per route through route option', t => {
-  t.plan(3)
-
+test('serializer per route through route option', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin, {
@@ -353,60 +313,50 @@ test('serializer per route through route option', t => {
       .send({ pippo: 'pluto' })
   })
 
-  t.test('application/x-protobuf -> protobuf', t => {
-    t.plan(3)
-    fastify.inject({
+  await t.test('application/x-protobuf -> protobuf', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/x-protobuf'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/x-protobuf')
-      t.strictSame(res.payload, AwesomeMessage.encode(AwesomeMessage.create({ pippo: 'pluto' })).finish().toString())
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/x-protobuf')
+    assert.deepStrictEqual(res.payload, AwesomeMessage.encode(AwesomeMessage.create({ pippo: 'pluto' })).finish().toString())
   })
 
-  t.test('route level should not pullute global cache', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('route level should not pullute global cache', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request2',
       payload: {},
       headers: {
         accept: 'application/yaml'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/yaml')
-      t.strictSame(res.payload, 'my-custom-string')
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/yaml')
+    assert.deepStrictEqual(res.payload, 'my-custom-string')
   })
 
-  t.test('overwrite by fastify reply', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('overwrite by fastify reply', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request3',
       payload: {},
       headers: {
         accept: 'application/yaml'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/yaml')
-      t.strictSame(res.payload, 'foo-bar-baz')
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/yaml')
+    assert.deepStrictEqual(res.payload, 'foo-bar-baz')
   })
 })
 
-test('serializer without conf', t => {
-  t.plan(2)
-
+test('serializer without conf', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin)
@@ -415,49 +365,41 @@ test('serializer without conf', t => {
     reply.send({ pippo: 'pluto' })
   })
 
-  t.test('application/json -> json', t => {
-    t.plan(3)
-
-    fastify.inject({
+  await t.test('application/json -> json', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/json'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/json; charset=utf-8')
-      t.strictSame(res.payload, JSON.stringify({ pippo: 'pluto' }))
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    assert.deepStrictEqual(res.payload, JSON.stringify({ pippo: 'pluto' }))
   })
 
-  t.test('application/yaml -> 406', t => {
-    t.plan(4)
-
-    fastify.inject({
+  await t.test('application/yaml -> 406', async () => {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/yaml'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/json; charset=utf-8')
-      t.strictSame(res.statusCode, 406)
-      t.strictSame(res.payload, JSON.stringify({
-        statusCode: 406,
-        error: 'Not Acceptable',
-        message: 'Allowed: application/json'
-      }))
     })
+
+    assert.deepStrictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    assert.deepStrictEqual(res.statusCode, 406)
+    assert.deepStrictEqual(res.payload, JSON.stringify({
+      statusCode: 406,
+      error: 'Not Acceptable',
+      message: 'Allowed: application/json'
+    }))
   })
 })
 
-test('serializer cache', t => {
-  t.plan(1)
-
+test('serializer cache', async t => {
   const fastify = Fastify()
 
   fastify.register(plugin, {
@@ -469,39 +411,35 @@ test('serializer cache', t => {
     ]
   })
 
-  t.test('it shoud populate cache', t => {
-    t.plan(8)
-
+  await t.test('it shoud populate cache', async () => {
     fastify.get('/request', function (req, reply) {
-      t.strictSame(Object.keys(reply.serializer.cache), ['application/cache'])
+      assert.deepStrictEqual(Object.keys(reply.serializer.cache), ['application/cache'])
 
       reply.send('cache')
     })
 
-    fastify.inject({
+    const res1 = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/cache'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/cache')
-      t.strictSame(res.payload, 'cache')
     })
 
-    fastify.inject({
+    assert.deepStrictEqual(res1.headers['content-type'], 'application/cache')
+    assert.deepStrictEqual(res1.payload, 'cache')
+
+    const res2 = await fastify.inject({
       method: 'GET',
       url: '/request',
       payload: {},
       headers: {
         accept: 'application/cache'
       }
-    }, (err, res) => {
-      t.error(err)
-      t.strictSame(res.headers['content-type'], 'application/cache')
-      t.strictSame(res.payload, 'cache')
     })
+
+    assert.deepStrictEqual(res2.headers['content-type'], 'application/cache')
+    assert.deepStrictEqual(res2.payload, 'cache')
   })
 })


### PR DESCRIPTION
Hi!
I moved the test suite from tap to node test framework.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
