### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @fastify/accepts-serializer
 
-![CI](https://github.com/fastify/fastify-accepts-serializer/workflows/CI/badge.svg?branch=master)
+[![CI](https://github.com/fastify/fastify-accepts-serializer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/fastify/fastify-accepts-serializer/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@fastify/accepts-serializer)](https://www.npmjs.com/package/@fastify/accepts-serializer)
 [![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
 


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge