### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   ],
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "msgpack5": "^6.0.2",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.