### PR TITLE
refactor(types): migrate from tsd to tstyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:unit": "c8 --100 node --test",
-    "test:typescript": "tsd"
+    "test:typescript": "tstyche"
   },
   "repository": {
     "type": "git",
@@ -58,7 +58,7 @@
     "msgpack5": "^6.0.2",
     "neostandard": "^0.13.0",
     "protobufjs": "^8.0.0",
-    "tsd": "^0.33.0",
+    "tstyche": "^7.0.0",
     "yamljs": "^0.3.0"
   },
   "dependencies": {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,6 +1,6 @@
 import Fastify from 'fastify'
 import fastifyAcceptsSerializer from '..'
-import { expectError } from 'tsd'
+import { expect } from 'tstyche'
 
 const fastify = Fastify()
 
@@ -15,9 +15,15 @@ fastify.register(fastifyAcceptsSerializer, {
   default: 'application/json' // MIME type used if Accept header don't match anything
 })
 
-expectError(fastify.register(fastifyAcceptsSerializer, { }))
-expectError(fastify.register(fastifyAcceptsSerializer, { serializers: [], default: 1 }))
-expectError(fastify.register(fastifyAcceptsSerializer, { serializers: [{}], default: 'application/json' }))
+expect(fastify.register).type.not.toBeCallableWith(fastifyAcceptsSerializer, {})
+expect(fastify.register).type.not.toBeCallableWith(fastifyAcceptsSerializer, {
+  serializers: [],
+  default: 1
+})
+expect(fastify.register).type.not.toBeCallableWith(fastifyAcceptsSerializer, {
+  serializers: [{}],
+  default: 'application/json'
+})
 
 // Per-router serializers
 fastify.get('/request', {


### PR DESCRIPTION
Proposal:

- migrate from `tsd` to `tstyche`

PR of Reference: 
  - https://github.com/fastify/fastify/pull/6532
  - https://github.com/fastify/fastify/pull/6525

